### PR TITLE
Converting cuDF dfs to cuPy arrays in categorical encoders

### DIFF
--- a/tests/xfeat/cat_encoder/test_concat_combination.py
+++ b/tests/xfeat/cat_encoder/test_concat_combination.py
@@ -35,7 +35,10 @@ def test_concat_combination(dataframes):
             "col1col3_combi",
             "col2col3_combi",
         ]
-        assert df_encoded["col1col3_combi"].tolist() == ["aX", "bY"]
+        if cudf_is_available() and isinstance(df_encoded, cudf.DataFrame):
+            assert df_encoded["col1col3_combi"].to_arrow().to_pylist() == ["aX", "bY"]
+        else:
+            assert df_encoded["col1col3_combi"].tolist() == ["aX", "bY"]
 
     for df in dataframes:
         encoder = ConcatCombination(output_suffix="", drop_origin=True)
@@ -45,12 +48,21 @@ def test_concat_combination(dataframes):
             "col1col3",
             "col2col3",
         ]
-        assert df_encoded["col2col3"].tolist() == ["@X", "%Y"]
+        if cudf_is_available() and isinstance(df_encoded, cudf.DataFrame):
+            assert df_encoded["col2col3"].to_arrow().to_pylist() == ["@X", "%Y"]
+        else:
+            assert df_encoded["col2col3"].tolist() == ["@X", "%Y"]
 
     for df in dataframes:
         encoder = ConcatCombination(output_suffix="", drop_origin=True, r=3)
         df_encoded = encoder.fit_transform(df)
-        assert df_encoded.columns.tolist() == [
-            "col1col2col3",
-        ]
-        assert df_encoded["col1col2col3"].tolist() == ["a@X", "b%Y"]
+        if cudf_is_available() and isinstance(df_encoded, cudf.DataFrame):
+            assert df_encoded.columns.tolist() == [
+                "col1col2col3",
+            ]
+            assert df_encoded["col1col2col3"].to_arrow().to_pylist() == ["a@X", "b%Y"]
+        else:
+            assert df_encoded.columns.tolist() == [
+                "col1col2col3",
+            ]
+            assert df_encoded["col1col2col3"].tolist() == ["a@X", "b%Y"]

--- a/xfeat/cat_encoder/_basic_encoder.py
+++ b/xfeat/cat_encoder/_basic_encoder.py
@@ -7,7 +7,7 @@ import pandas as pd
 from xfeat.utils import analyze_columns
 from xfeat.base import TransformerMixin
 from xfeat.types import XDataFrame
-
+import cudf
 
 class LabelEncoder(TransformerMixin):
     """Encode labels with numerical values between `0` and `n_unique - 1`.
@@ -124,8 +124,11 @@ class LabelEncoder(TransformerMixin):
 
         for col in input_cols:
             out_col = self._output_prefix + col + self._output_suffix
-            X = self._uniques[col].get_indexer(new_df[col])
-
+            if isinstance(new_df, pd.DataFrame):
+                X = self._uniques[col].get_indexer(new_df[col])
+            elif isinstance(new_df, cudf.DataFrame):
+                X = self._uniques[col].get_indexer(new_df[col].to_array())
+            
             if self._unseen == "n_unique":
                 missing_values = new_df[col].isna()
                 unseen_values = np.invert(new_df[col].isin(self._uniques[col]))

--- a/xfeat/cat_encoder/_basic_encoder.py
+++ b/xfeat/cat_encoder/_basic_encoder.py
@@ -7,7 +7,12 @@ import pandas as pd
 from xfeat.utils import analyze_columns
 from xfeat.base import TransformerMixin
 from xfeat.types import XDataFrame
-import cudf
+from xfeat.utils import cudf_is_available
+
+try:
+    import cudf  # NOQA
+except ImportError:
+    cudf = None
 
 class LabelEncoder(TransformerMixin):
     """Encode labels with numerical values between `0` and `n_unique - 1`.
@@ -124,11 +129,10 @@ class LabelEncoder(TransformerMixin):
 
         for col in input_cols:
             out_col = self._output_prefix + col + self._output_suffix
-            if isinstance(new_df, pd.DataFrame):
-                X = self._uniques[col].get_indexer(new_df[col])
-            elif isinstance(new_df, cudf.DataFrame):
+            if cudf_is_available() and isinstance(new_df, cudf.DataFrame):
                 X = self._uniques[col].get_indexer(new_df[col].to_array())
-            
+            else:
+                X = self._uniques[col].get_indexer(new_df[col])
             if self._unseen == "n_unique":
                 missing_values = new_df[col].isna()
                 unseen_values = np.invert(new_df[col].isin(self._uniques[col]))

--- a/xfeat/cat_encoder/_count_encoder.py
+++ b/xfeat/cat_encoder/_count_encoder.py
@@ -3,13 +3,19 @@ from typing import List, Dict, Optional
 
 import numpy as np
 import pandas as pd
+
 from sklearn.base import BaseEstimator
 from sklearn.base import TransformerMixin as SKTransformerMixin
 from sklearn.utils.validation import column_or_1d, check_is_fitted
 
 from xfeat.types import XDataFrame
 from xfeat.base import TransformerMixin
+from xfeat.utils import cudf_is_available
 
+try:
+    import cudf  # NOQA
+except ImportError:
+    cudf = None
 
 class CountEncoder(TransformerMixin):
     """Encode frequency of categorical values.
@@ -128,6 +134,8 @@ class _CountEncoder(BaseEstimator, SKTransformerMixin):
 
     def fit(self, X, y=None):
         """Fit to ndarray, then transform it."""
+        if cudf_is_available() and isinstance(X, cudf.Series):
+            X = X.to_array()
         X = column_or_1d(X, warn=True)
 
         # Label encoding if necessary
@@ -147,6 +155,8 @@ class _CountEncoder(BaseEstimator, SKTransformerMixin):
     def transform(self, X):
         """Transform ndarray values."""
         check_is_fitted(self, "classes_")
+        if cudf_is_available() and isinstance(X, cudf.Series):
+            X = X.to_array()
         X = column_or_1d(X, warn=True)
 
         # Label encoding if necessary

--- a/xfeat/cat_encoder/_target_encoder.py
+++ b/xfeat/cat_encoder/_target_encoder.py
@@ -398,7 +398,8 @@ class _CuPy_MeanEncoder(BaseEstimator):
         """
         # Label encoding if necessary
         if not cupy.can_cast(X.dtype, cupy.int):
-            X = X.to_array()
+            if isinstance(X, cudf.Series):
+                X = X.to_array()
             X, uniques = pd.Series(cupy.asnumpy(X)).factorize()
             X = cudf.Series(X)
             self._label_encoding_uniques = uniques

--- a/xfeat/cat_encoder/_target_encoder.py
+++ b/xfeat/cat_encoder/_target_encoder.py
@@ -398,6 +398,7 @@ class _CuPy_MeanEncoder(BaseEstimator):
         """
         # Label encoding if necessary
         if not cupy.can_cast(X.dtype, cupy.int):
+            X = X.to_array()
             X, uniques = pd.Series(cupy.asnumpy(X)).factorize()
             X = cudf.Series(X)
             self._label_encoding_uniques = uniques

--- a/xfeat/cat_encoder/_target_encoder.py
+++ b/xfeat/cat_encoder/_target_encoder.py
@@ -398,7 +398,7 @@ class _CuPy_MeanEncoder(BaseEstimator):
         """
         # Label encoding if necessary
         if not cupy.can_cast(X.dtype, cupy.int):
-            if isinstance(X, cudf.Series):
+            if cudf_is_available() and isinstance(X, cudf.Series):
                 X = X.to_array()
             X, uniques = pd.Series(cupy.asnumpy(X)).factorize()
             X = cudf.Series(X)


### PR DESCRIPTION
Passing categorical columns to label and target encoders resulted in an error because they weren't properly being converted to cupy arrays. 

This PR adds a check and performs the conversion necessary