### PR TITLE
Fix `mypy` errors

### DIFF
--- a/xfeat/cat_encoder/_target_encoder.py
+++ b/xfeat/cat_encoder/_target_encoder.py
@@ -28,7 +28,7 @@ def _get_index(arr: np.ndarray, val: np.ndarray):
     return index
 
 
-def _get_index_cupy(arr: CupyArray, val: CupyArray):
+def _get_index_cupy(arr: "cupy.array", val: "cupy.array"):
     index = cupy.searchsorted(arr, val)
     return index
 

--- a/xfeat/cat_encoder/_target_encoder.py
+++ b/xfeat/cat_encoder/_target_encoder.py
@@ -16,11 +16,9 @@ from xfeat.utils import cudf_is_available
 try:
     import cudf  # NOQA
     import cupy  # NOQA
-    CupyArray = cupy.array
 except ImportError:
     cudf = None
     cupy = None
-    CupyArray = None
 
 
 def _get_index(arr: np.ndarray, val: np.ndarray):

--- a/xfeat/optuna_selector/_kbest_explorer.py
+++ b/xfeat/optuna_selector/_kbest_explorer.py
@@ -1,4 +1,4 @@
-from typing import Union, List
+from typing import Union, List, Optional
 
 import optuna
 
@@ -22,7 +22,7 @@ class KBestThresholdExplorer(OptunaSelectorMixin):
         kbest_search_range: Union[List[int], str] = "auto",
     ):
         self._selector = selector
-        self._trial = None
+        self._trial = None  # type: Optional[optuna.trial.FrozenTrial]
         self.kbest_search_range = kbest_search_range
 
         self._search_space = {


### PR DESCRIPTION
[Optuna](https://optuna.org) provides the type hints for its application since [`v2.1.0`](https://github.com/optuna/optuna/releases/tag/v2.1.0).

It causes a new `mypy` error as follows:

```console
$ mypy .
xfeat/optuna_selector/_kbest_explorer.py:69: error: Incompatible types in assignment (expression has type "FrozenTrial", variable has type "None")
```

This PR adds type annotation to `KBestThresholdExplorer.trial` to avoid the error.

In addition, `CupyArray` in `xfeat/cat_encoder/_target_encoder.py` causes another mypy error, and I also fix it using the string annotation.

```console
xfeat/cat_encoder/_target_encoder.py:31: error: Variable "xfeat.cat_encoder._target_encoder.CupyArray" is not valid as a type
xfeat/cat_encoder/_target_encoder.py:31: note: See https://mypy.readthedocs.io/en/latest/common_issues.html#variables-vs-type-aliases
```